### PR TITLE
Fix naming in release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           tag_name: ${{ needs.read-package-json.outputs.package_version}}
           release_name: Release ${{ needs.read-package-json.outputs.package_version}}
           body: |
-            Release of the Active Window Package for the Grid Editor
+            Release of the Photoshop Package for the Grid Editor
           draft: false
           prerelease: false
       - name: Save release output
@@ -85,7 +85,7 @@ jobs:
         with:
           upload_url: ${{ needs.create-github-release.outputs.upload_url }}
           asset_path: package-archive.zip
-          asset_name: package-active-win-${{ matrix.os }}.zip
+          asset_name: package-photoshop-${{ matrix.os }}.zip
           asset_content_type: application/zip
   publish-release:
     needs: [build, create-github-release]


### PR DESCRIPTION
Hi @danim1130,

I noticed that the release assets for this Photoshop package had the incorrect title and file names. Here's a small patch to fix that :)